### PR TITLE
Fix it so it works with valid http|https urls again

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -22,7 +22,7 @@ import Layout from "../layouts/Layout.astro";
       try {
         var decoded = atob(pieces.join('')); // Decode the base64 string
         var urled = new URL(decoded);
-				if (urled.protocol !== 'https' && urled.protocol !== 'http') {
+				if (urled.protocol !== 'https:' && urled.protocol !== 'http:') {
 					throw new Error('Invalid protocol');
 				}
         window.location.href = decoded;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ import Layout from "../layouts/Layout.astro";
 			try {
 				var urled = new URL(website);
 				// Make sure the URL is http or https
-				if (urled.protocol !== 'https' && urled.protocol !== 'http') {
+				if (urled.protocol !== 'https:' && urled.protocol !== 'http:') {
 					Toastify({
 						text: "Invalid URL protocol.",
 						gravity: "top",


### PR DESCRIPTION
Fixed the valid protocol check so it passes with valid http/https urls, URL.protocol returns the protocol ending with `:` so it was failing the check for http|https