### PR TITLE
Add support for Internationalized Domain Names (IDNs)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,12 +6,12 @@ import Layout from "../layouts/Layout.astro";
 	<link rel="preload" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 	<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js" defer></script>
 	<script is:inline>
+		import punycode from 'punycode';
 		var bases = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/', '='];
-
 		function longer() {
 			var website = document.getElementById("website").value;
-            var strippedURL = website.replace(/^(https?:\/\/)?([^\/]+).*/, "$2");
-            var website = punycode.toASCII(strippedURL);
+            		var strippedURL = website.replace(/^(https?:\/\/)?([^\/]+).*/, "$2");
+            		website = punycode.toASCII(strippedURL);
 			try {
 				var urled = new URL(website);
 				// Make sure the URL is http or https

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,8 @@ import Layout from "../layouts/Layout.astro";
 
 		function longer() {
 			var website = document.getElementById("website").value;
+            var strippedURL = website.replace(/^(https?:\/\/)?([^\/]+).*/, "$2");
+            var website = punycode.toASCII(strippedURL);
 			try {
 				var urled = new URL(website);
 				// Make sure the URL is http or https


### PR DESCRIPTION
This PR adds support for Internationalized Domain Names (IDNs). Previously, the code did not handle IDNs properly. This was an issue for users who wanted to use the service with non-ASCII URLs, such as:

- https://世界大学.top/
- https://www.транспорт.com
- https://www.קום.קום
- https://www.日本語.jp
- https://www.موقع.وزارة-الاتصالات.gov.sa
- https://ουτοπία.δπθ.gr

The changes in this PR fix this issue by converting the unicode domain name to Punycode, which is a standard ASCII representation of the domain name that can be used in the URL.

With these changes, the service can now handle and lengthen URLs with IDNs.

The relevant changes are as follows:

```javascript
var website = document.getElementById("website").value;
var strippedURL = website.replace(/^(https?:\/\/)?([^\/]+).*/, "$2");
var website = punycode.toASCII(strippedURL);
```

This line of code extracts the domain part from the input URL:

```javascript
var strippedURL = website.replace(/^(https?:\/\/)?([^\/]+).*/, "$2");
```
The regular expression `^(https?:\/\/)?([^\/]+).*` matches the beginning of the URL, which may optionally start with `http://` or `https://`, followed by the domain part of the URL, and any additional characters that come after it. The replace method then replaces the entire string with the domain part, which is used for subsequent Punycode conversion.